### PR TITLE
Fix exclude for Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SwiftCoAP",
-            dependencies: [],
-            exclude: ["Example_Projects"]),
+            dependencies: []),
         .testTarget(
             name: "SwiftCoAPTests",
             dependencies: ["SwiftCoAP"]),


### PR DESCRIPTION
Xcode 13 warns of wrong exclude. The `exclude: ["Example_Projects"]` never were excluding anything, because the `Example_Projects` folder is outside `Sources/SwiftCoAP`. Still can't find the way not to download the examples along the source when resolving package, though it's never built.