### PR TITLE
Tell the SCClient delegate an underlying error

### DIFF
--- a/Example_Projects/SwiftCoAPClientExample/SwiftCoAPClientExample.xcodeproj/xcshareddata/xcschemes/SwiftCoAPClientExample.xcscheme
+++ b/Example_Projects/SwiftCoAPClientExample/SwiftCoAPClientExample.xcodeproj/xcshareddata/xcschemes/SwiftCoAPClientExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example_Projects/SwiftCoAPServerExample/SwiftCoAPServerExample.xcodeproj/project.pbxproj
+++ b/Example_Projects/SwiftCoAPServerExample/SwiftCoAPServerExample.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "Wojtek Kordylewski";
 				TargetAttributes = {
 					9316D7951B2AE54400B0B70D = {
@@ -198,10 +198,9 @@
 			};
 			buildConfigurationList = 9316D7911B2AE54400B0B70D /* Build configuration list for PBXProject "SwiftCoAPServerExample" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -313,6 +312,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -369,6 +369,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/Example_Projects/SwiftCoAPServerExample/SwiftCoAPServerExample.xcodeproj/xcshareddata/xcschemes/SwiftCoAPServerExample.xcscheme
+++ b/Example_Projects/SwiftCoAPServerExample/SwiftCoAPServerExample.xcodeproj/xcshareddata/xcschemes/SwiftCoAPServerExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/SwiftCoAP/SCClient.swift
+++ b/Sources/SwiftCoAP/SCClient.swift
@@ -263,8 +263,16 @@ public class SCClient: NSObject {
         delegate?.swiftCoapClient(self, didFailWithError: NSError(domain: SCMessage.kCoapErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey : errorDescription]))
     }
     
-    fileprivate func notifyDelegateWithErrorCode(_ clientErrorCode: SCClientErrorCode) {
-        delegate?.swiftCoapClient(self, didFailWithError: NSError(domain: SCMessage.kCoapErrorDomain, code: clientErrorCode.rawValue, userInfo: [NSLocalizedDescriptionKey : clientErrorCode.descriptionString()]))
+    fileprivate func notifyDelegateWithErrorCode(_ clientErrorCode: SCClientErrorCode, underlyingError: NSError? = nil) {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: clientErrorCode.descriptionString()]
+        if let underlyingError = underlyingError {
+            userInfo[NSUnderlyingErrorKey] = underlyingError
+        }
+        let error =  NSError(domain: SCMessage.kCoapErrorDomain,
+                             code: clientErrorCode.rawValue,
+                             userInfo: userInfo)
+        
+        delegate?.swiftCoapClient(self, didFailWithError: error)
     }
     
     fileprivate func handleBlock2WithMessage(_ message: SCMessage) {
@@ -450,7 +458,7 @@ extension SCClient: SCCoAPTransportLayerDelegate {
     }
     
     public func transportLayerObject(_ transportLayerObject: SCCoAPTransportLayerProtocol, didFailWithError error: NSError) {
-        notifyDelegateWithErrorCode(.transportLayerSendError)
+        notifyDelegateWithErrorCode(.transportLayerSendError, underlyingError: error)
         transmissionTimer?.invalidate()
         transmissionTimer = nil
     }

--- a/Sources/SwiftCoAP/SCMessage.swift
+++ b/Sources/SwiftCoAP/SCMessage.swift
@@ -261,7 +261,6 @@ extension SCCoAPUDPTransportLayer: SCCoAPTransportLayerProtocol {
             defer { semaphore.signal() }
             let dd = DispatchData(bytes: pointer)
             sec_protocol_options_add_pre_shared_key(tlsOptions.securityProtocolOptions, dd as __DispatchData, dd as __DispatchData)
-            // TLS_PSK_WITH_AES_128_GCM_SHA256 as in Apple's example project. 'Boring SSL' complains anyway.
             sec_protocol_options_append_tls_ciphersuite(tlsOptions.securityProtocolOptions, tls_ciphersuite_t(rawValue: UInt16(suite))!)
         }
         semaphore.wait()


### PR DESCRIPTION
Extends the errors passed to the `SCClient` delegate. New field to pass `NSUnderlyingErrorKey` within `userInfo` of the `NSError` constructed from `SCClientErrorCode` is added. 