### PR TITLE
Making cancelConnection method public

### DIFF
--- a/Sources/SwiftCoAP/SCMessage.swift
+++ b/Sources/SwiftCoAP/SCMessage.swift
@@ -53,6 +53,7 @@ public protocol SCCoAPTransportLayerProtocol: AnyObject {
     func getMessageId(for endpoint:NWEndpoint) -> UInt16
     func cancelMessageTransmission(to endpoint: NWEndpoint, withToken: UInt64)
     // Closes all connections to the endpoints
+    func cancelConnection(to endpoint: NWEndpoint)
     func closeAllTransmissions()
     
 }
@@ -372,7 +373,7 @@ extension SCCoAPUDPTransportLayer: SCCoAPTransportLayerProtocol {
         return tlsOptions
     }
     
-    private func cancelConnection(to endpoint: NWEndpoint) {
+    public func cancelConnection(to endpoint: NWEndpoint) {
         operationsQueue.sync { [weak self] in
             guard let self = self else { return }
             if let coapConnection = self.connections[endpoint] {


### PR DESCRIPTION
It's used to close transmission channel between the phone and the device. Useful, when user deletes the device