### PR TITLE
Executing notifyDelegatesAboutError with barrier flag

### DIFF
--- a/Sources/SwiftCoAP/SCMessage.swift
+++ b/Sources/SwiftCoAP/SCMessage.swift
@@ -219,9 +219,11 @@ public final class SCCoAPUDPTransportLayer {
     }
     
     fileprivate func notifyDelegatesAboutError(for endpoint: NWEndpoint, error: Error) {
-        self.transportLayerDelegates.forEach { (key, value) in
-            if key.endpoint == endpoint {
-                value.delegate.transportLayerObject(self, didFailWithError: error as NSError)
+        operationsQueue.sync(flags: .barrier) {
+            self.transportLayerDelegates.forEach { (key, value) in
+                if key.endpoint == endpoint {
+                    value.delegate.transportLayerObject(self, didFailWithError: error as NSError)
+                }
             }
         }
     }


### PR DESCRIPTION
Upon investigating crashes in some cases `cancelConnection` would create deadlock resulting in crash for `notifyDelegatesAboutError`

This PR executes `notifyDelegatesAboutError` blocking any other operations until it's finished

@illabo please have a look also 