### PR TITLE
Delete delegate on operation queue in handleReceivedMessage

### DIFF
--- a/Sources/SwiftCoAP/SCMessage.swift
+++ b/Sources/SwiftCoAP/SCMessage.swift
@@ -204,7 +204,7 @@ public final class SCCoAPUDPTransportLayer {
             delegate.delegate.transportLayerObject(self, didReceiveData: rawData, fromEndpoint: connection.endpoint)
             if delegate.observation == false && message.type == .acknowledgement {
                 operationsQueue.sync{ [weak self] in
-                    self?.transportLayerDelegates.removeValue(forKey: id)
+                    _ = self?.transportLayerDelegates.removeValue(forKey: id)
                 }
             }
         }
@@ -976,7 +976,7 @@ public class SCMessage: NSObject {
     //MARK: Internal Methods (allowed to use)
     
     public convenience init(code: SCCodeValue, type: SCType, payload: Data?) {
-        self.init()   
+        self.init()
         self.code = code
         self.type = type
         self.payload = payload


### PR DESCRIPTION
It was the only place where delegates array might be written from different queue. 
@vodovozovge, @hoangnami, let's run the main app with this commit on M1 Mac to confirm if it cures the issue Yoan reported.
